### PR TITLE
✨ Add Errorable Helpers, Export Errorables at the Top Level

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -32,13 +32,22 @@ type RedirectToLogin = StrongRedirect<
 ### Define Loader
 
 ```ts
-import { StrongLoader } from "remix-strong-routes";
+import { StrongLoader, toSuccess, toError } from "remix-strong-routes";
 
 const strongLoader: StrongLoader<
   FooResponse,
   BarResponse,
   RedirectToLogin
-> = async ({ context, request, params }) => {
+> = async (
+  { context, request, params },
+  /**
+   * Defining your success & error handlers in the arguments of the loader or
+   * action strengthens the types, as they can inherit the type arguments of
+   * StrongLoader.
+   */
+  toComponent = toSuccess,
+  toErrorBoundary = toError
+) => {
   // Try to validate a session
   if (await isUserLoggedIn(request)) {
     // Return a redirect object
@@ -60,7 +69,7 @@ const strongLoader: StrongLoader<
     };
 
     // Return a type safe error tuple indicating success
-    return [fooResponse, null];
+    return toComponent(fooResponse);
   } catch (e) {
     // Build a typesafe response object
     const barResponse: BarResponse = {
@@ -69,7 +78,7 @@ const strongLoader: StrongLoader<
     };
 
     // Return a type safe error tuple indicating failure
-    return [null, barData];
+    return toErrorBoundary(barResponse);
   }
 };
 ```

--- a/src/errorable.test.ts
+++ b/src/errorable.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { isError, isSuccess, toError, toSuccess } from ".";
+
+describe(isSuccess.name, () => {
+  it("returns true when the errorable is a success", () => {
+    expect(isSuccess(["foo", null])).toBe(true);
+  });
+
+  it("returns false when the errorable is an error", () => {
+    expect(isSuccess([null, new Error("foo")])).toBe(false);
+  });
+});
+
+describe(isError.name, () => {
+  it("returns true when the errorable is an error", () => {
+    expect(isError([null, new Error("foo")])).toBe(true);
+  });
+
+  it("returns false when the errorable is a success", () => {
+    expect(isError(["foo", null])).toBe(false);
+  });
+});
+
+describe(toSuccess.name, () => {
+  it("returns an errorable success", () => {
+    expect(toSuccess("foo")).toStrictEqual(["foo", null]);
+  });
+});
+
+describe(toError.name, () => {
+  it("returns an errorable error", () => {
+    expect(toError(new Error("foo"))).toStrictEqual([null, new Error("foo")]);
+  });
+});

--- a/src/errorable.ts
+++ b/src/errorable.ts
@@ -1,0 +1,27 @@
+export type ErrorableSuccess<T> = [T, null];
+
+export type ErrorableError<E> = [null, E];
+
+export type Errorable<T, E = unknown> = ErrorableSuccess<T> | ErrorableError<E>;
+
+export const isSuccess = <T, E>(
+  errorable: Errorable<T, E>
+): errorable is ErrorableSuccess<T> => errorable[1] === null;
+
+export const isError = <T, E>(
+  errorable: Errorable<T, E>
+): errorable is ErrorableError<E> => errorable[0] === null;
+
+export type ToSuccessFn<T, E> = (value: T) => Errorable<T, E>;
+
+export const toSuccess = <T, E>(value: T): Errorable<T, E> => [value, null];
+
+export type ToErrorFn<T, E> = (error: E) => Errorable<T, E>;
+
+export const toError = <T, E>(error: E): Errorable<T, E> => [null, error];
+
+export type ErrorableFnError<
+  F extends
+    | ((...args: any[]) => Promise<Errorable<unknown, Error>>)
+    | ((...args: any[]) => Errorable<unknown, Error>)
+> = Exclude<Awaited<ReturnType<F>>[1], null>;

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -20,6 +20,7 @@ import {
 } from "./";
 import { strongResponse } from "./strongResponse";
 import { Form } from "@remix-run/react";
+import { toError, toSuccess } from "./errorable";
 
 describe("strongResponse", () => {
   it("should create and format a response with a data object and status code", async () => {
@@ -84,14 +85,18 @@ describe("buildStrongRoute", () => {
     FooResponse,
     BarResponse,
     RedirectResponse
-  > = async ({ request }) => {
+  > = async (
+    { request },
+    toComponent = toSuccess,
+    toErrorBoundary = toError
+  ) => {
     const url = new URL(request.url);
     if (url.pathname === "/bar") {
-      return [null, barResponse];
+      return toErrorBoundary(barResponse);
     }
 
     if (url.pathname === "/foo") {
-      return [fooResponse, null];
+      return toComponent(fooResponse);
     }
 
     return redirectResponse;
@@ -101,14 +106,18 @@ describe("buildStrongRoute", () => {
     FooResponse,
     BarResponse,
     RedirectResponse
-  > = async ({ request }) => {
+  > = async (
+    { request },
+    toComponent = toSuccess,
+    toErrorBoundary = toError
+  ) => {
     const url = new URL(request.url);
     if (url.pathname === "/bar") {
-      return [null, barResponse];
+      return toErrorBoundary(barResponse);
     }
 
     if (url.pathname === "/foo") {
-      return [fooResponse, null];
+      return toComponent(fooResponse);
     }
 
     return redirectResponse;

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,3 +8,4 @@ export {
   StrongRedirect,
 } from "./types";
 export { HttpStatusCode } from "./HttpStatusCode";
+export { Errorable, isSuccess, isError, toSuccess, toError } from "./errorable";

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,8 +12,7 @@ import {
   NonRedirectStatus,
   RedirectStatus,
 } from "./HttpStatusCode";
-
-export type Errorable<T, E> = readonly [T, null] | readonly [null, E];
+import { Errorable, ToErrorFn, ToSuccessFn } from "./errorable";
 
 export interface StrongResponse<T, S extends HttpStatusCode>
   extends ResponseInit {
@@ -38,7 +37,9 @@ export type StrongLoader<
   Failure extends StrongResponse<unknown, NonRedirectStatus>,
   Redirect extends StrongResponse<string, RedirectStatus> = never
 > = (
-  args: DataFunctionArgs
+  args: DataFunctionArgs,
+  toComponent?: ToSuccessFn<Success, Failure>,
+  toErrorBoundary?: ToErrorFn<Success, Failure>
 ) => [Redirect] extends never
   ? Promise<Errorable<Success, Failure>>
   : Promise<Redirect | Errorable<Success, Failure>>;


### PR DESCRIPTION
## What's Changed?

* Rather than duplicate `Errorable` functionality, it's easier to import from `remix-strong-routes`.  
  * Unit tests have been added for `Errorable` helpers.
* Co-locating our helper functions also give us the ability to harden the types ([example](https://github.com/Fuiste/remix-strong-routes/blob/0da03335dbf1eaaad401015f3936d9dfc36880f9/README.md#define-loader))

## Testing Steps

Other than the new exports, no behavior should have changed.  Test suite should be green.