### PR TITLE
🐛 Brand Data Function Type to Harden BuildStrongRemixRouteExportsOpts

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,20 +71,25 @@ type RedirectToLogin = StrongRedirect<
 ### Define Loader
 
 ```ts
-import { StrongLoader, succeed, fail, redirect } from "remix-strong-routes";
+import { strongLoader } from "remix-strong-routes";
 
-const loader: StrongLoader<BarResponse, FooResponse, RedirectToLogin> = async ({
-  context,
-  request,
-  params,
-}) => {
+const loader = strongLoader<
+  BarResponse, 
+  FooResponse, 
+  RedirectToLogin
+>(async (
+  { context, request, params }, 
+  { fail, redirect, succeed }
+) => {
   // Try to validate a session
   if (await isUserLoggedIn(request)) {
-    // Return a redirect object
+    // Build a redirect object
     const redirectToLogin: RedirectToLogin = {
       data: "/login",
       status: HttpStatusCode.MOVED_PERMANENTLY,
     };
+
+    // Return a type-safe redirect
     return redirect(redirectToLogin);
   }
 
@@ -92,39 +97,42 @@ const loader: StrongLoader<BarResponse, FooResponse, RedirectToLogin> = async ({
     // Try to load some data
     const fooData = await getFooData();
 
-    // Build a typesafe response object
+    // Build a type-safe response object
     const fooResponse: FooResponse = {
       data: fooData,
       status: HttpStatusCode.OK,
     };
 
-    // Return a type safe error tuple indicating success
+    // Return a type-safe success to your component
     return succeed(fooResponse);
   } catch (e) {
-    // Build a typesafe response object
+    // Build a type-safe response object
     const barResponse: BarResponse = {
       data: "Bar",
       status: HttpStatusCode.INTERNAL_SERVER_ERROR,
     };
 
-    // Return a type safe error tuple indicating failure
+    // Return a type-safe error to your error boundary
     return fail(barResponse);
   }
-};
+});
 ```
 
 ### Define Action
 
 ```ts
-import { StrongAction, succeed, fail, redirect } from "remix-strong-routes";
+import { strongAction } from "remix-strong-routes";
 
-const action: StrongAction<BarResponse, FooResponse, RedirectToLogin> = async ({
-  context,
-  request,
-  params,
-}) => {
+const action - strongAction<
+  BarResponse, 
+  FooResponse, 
+  RedirectToLogin
+>(async (
+  { context, request, params },
+  { fail, redirect, succeed }
+) => {
   // ... Same as the loader
-};
+});
 ```
 
 ### Define Route Component

--- a/README.md
+++ b/README.md
@@ -73,49 +73,44 @@ type RedirectToLogin = StrongRedirect<
 ```ts
 import { strongLoader } from "remix-strong-routes";
 
-const loader = strongLoader<
-  BarResponse, 
-  FooResponse, 
-  RedirectToLogin
->(async (
-  { context, request, params }, 
-  { fail, redirect, succeed }
-) => {
-  // Try to validate a session
-  if (await isUserLoggedIn(request)) {
-    // Build a redirect object
-    const redirectToLogin: RedirectToLogin = {
-      data: "/login",
-      status: HttpStatusCode.MOVED_PERMANENTLY,
-    };
+const loader = strongLoader<BarResponse, FooResponse, RedirectToLogin>(
+  async ({ context, request, params }, { fail, redirect, succeed }) => {
+    // Try to validate a session
+    if (await isUserLoggedIn(request)) {
+      // Build a redirect object
+      const redirectToLogin: RedirectToLogin = {
+        data: "/login",
+        status: HttpStatusCode.MOVED_PERMANENTLY,
+      };
 
-    // Return a type-safe redirect
-    return redirect(redirectToLogin);
-  }
+      // Return a type-safe redirect
+      return redirect(redirectToLogin);
+    }
 
-  try {
-    // Try to load some data
-    const fooData = await getFooData();
+    try {
+      // Try to load some data
+      const fooData = await getFooData();
 
-    // Build a type-safe response object
-    const fooResponse: FooResponse = {
-      data: fooData,
-      status: HttpStatusCode.OK,
-    };
+      // Build a type-safe response object
+      const fooResponse: FooResponse = {
+        data: fooData,
+        status: HttpStatusCode.OK,
+      };
 
-    // Return a type-safe success to your component
-    return succeed(fooResponse);
-  } catch (e) {
-    // Build a type-safe response object
-    const barResponse: BarResponse = {
-      data: "Bar",
-      status: HttpStatusCode.INTERNAL_SERVER_ERROR,
-    };
+      // Return a type-safe success to your component
+      return succeed(fooResponse);
+    } catch (e) {
+      // Build a type-safe response object
+      const barResponse: BarResponse = {
+        data: "Bar",
+        status: HttpStatusCode.INTERNAL_SERVER_ERROR,
+      };
 
-    // Return a type-safe error to your error boundary
-    return fail(barResponse);
-  }
-});
+      // Return a type-safe error to your error boundary
+      return fail(barResponse);
+    }
+  },
+);
 ```
 
 ### Define Action
@@ -124,8 +119,8 @@ const loader = strongLoader<
 import { strongAction } from "remix-strong-routes";
 
 const action - strongAction<
-  BarResponse, 
-  FooResponse, 
+  BarResponse,
+  FooResponse,
   RedirectToLogin
 >(async (
   { context, request, params },

--- a/src/buildStrongRoute.tsx
+++ b/src/buildStrongRoute.tsx
@@ -10,10 +10,9 @@ import {
 import { useStrongLoaderData, useStrongRouteError } from "./hooks";
 import { strongResponse } from "./strongResponse";
 import {
+  BrandedDataFunction,
   BuildStrongRemixRouteExportsOpts,
   PickDataAndStatus,
-  StrongAction,
-  StrongLoader,
   StrongRedirect,
   StrongRemixRouteExports,
   StrongResponse,
@@ -50,9 +49,7 @@ const handleDataFunctionForRemix = async <
   Failure extends StrongResponse<unknown, NonRedirectStatus> = never,
   Redirect extends StrongRedirect<string, RedirectStatus> = never,
 >(
-  dataFunction:
-    | StrongLoader<Failure, Success, Redirect>
-    | StrongAction<Failure, Success, Redirect>,
+  dataFunction: BrandedDataFunction<Failure, Success, Redirect>,
   args: DataFunctionArgs,
 ) => {
   const resultEffect = (await dataFunction(args)) as Effect.Effect<

--- a/src/effects.ts
+++ b/src/effects.ts
@@ -1,5 +1,0 @@
-import { Effect } from "effect";
-
-export const succeed = Effect.succeed;
-export const fail = Effect.fail;
-export const redirect = Effect.succeed;

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -12,18 +12,15 @@ import "isomorphic-fetch";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   HttpStatusCode,
-  StrongAction,
   StrongComponent,
   StrongErrorBoundary,
-  StrongLoader,
   StrongRedirect,
   StrongResponse,
   buildStrongRoute,
-  fail,
-  redirect,
-  succeed,
 } from "./";
 import { strongResponse } from "./strongResponse";
+import { strongLoader } from "./strongLoader";
+import { strongAction } from "./strongAction";
 
 describe("strongResponse", () => {
   it("should create and format a response with a data object and status code", async () => {
@@ -85,11 +82,11 @@ describe("buildStrongRoute", () => {
     status: HttpStatusCode.MOVED_PERMANENTLY,
   };
 
-  const loader: StrongLoader<
+  const loader = strongLoader<
     BarResponse,
     FooResponse | BazResponse,
     RedirectResponse
-  > = async ({ request }) => {
+  >(async ({ request }, { fail, succeed, redirect }) => {
     const url = new URL(request.url);
     if (url.searchParams.has("fail")) {
       return fail(barResponse);
@@ -100,13 +97,13 @@ describe("buildStrongRoute", () => {
     }
 
     return redirect(redirectResponse);
-  };
+  });
 
-  const action: StrongAction<
+  const action = strongAction<
     BarResponse,
     FooResponse | BazResponse,
     RedirectResponse
-  > = async ({ request }) => {
+  >(async ({ request }, { fail, succeed, redirect }) => {
     const url = new URL(request.url);
     if (url.searchParams.has("fail")) {
       return fail(barResponse);
@@ -117,7 +114,7 @@ describe("buildStrongRoute", () => {
     }
 
     return redirect(redirectResponse);
-  };
+  });
 
   const Component: StrongComponent<FooResponse | BazResponse> = (props) => {
     if (props.status === HttpStatusCode.ACCEPTED) return null;

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,4 +12,5 @@ export {
   NonRedirectStatus as NonRedirectStatusCode,
   RedirectStatus as RedirectStatusCode,
 } from "./HttpStatusCode";
-export * from "./effects";
+export { strongAction } from "./strongAction";
+export { strongLoader } from "./strongLoader";

--- a/src/strongAction.ts
+++ b/src/strongAction.ts
@@ -1,6 +1,12 @@
 import { DataFunctionArgs } from "@remix-run/server-runtime";
 import { NonRedirectStatus, RedirectStatus } from "./HttpStatusCode";
-import { StrongAction, StrongRedirect, StrongResponse } from "./types";
+import {
+  BrandedDataFunction,
+  StrongAction,
+  StrongRedirect,
+  StrongResponse,
+} from "./types";
+import { Effect } from "effect";
 
 export const strongAction =
   <
@@ -9,6 +15,10 @@ export const strongAction =
     Redirect extends StrongRedirect<string, RedirectStatus> = never,
   >(
     actionFn: StrongAction<Failure, Success, Redirect>,
-  ) =>
+  ): BrandedDataFunction<Failure, Success, Redirect> =>
   (args: DataFunctionArgs) =>
-    actionFn(args);
+    actionFn(args, {
+      fail: Effect.fail,
+      succeed: Effect.succeed,
+      redirect: Effect.succeed,
+    });

--- a/src/strongLoader.ts
+++ b/src/strongLoader.ts
@@ -1,6 +1,12 @@
-import { DataFunctionArgs, LoaderFunction } from "@remix-run/server-runtime";
+import { DataFunctionArgs } from "@remix-run/server-runtime";
 import { NonRedirectStatus, RedirectStatus } from "./HttpStatusCode";
-import { StrongLoader, StrongRedirect, StrongResponse } from "./types";
+import {
+  BrandedDataFunction,
+  StrongLoader,
+  StrongRedirect,
+  StrongResponse,
+} from "./types";
+import { Effect } from "effect";
 
 export const strongLoader =
   <
@@ -9,6 +15,10 @@ export const strongLoader =
     Redirect extends StrongRedirect<string, RedirectStatus> = never,
   >(
     loaderFn: StrongLoader<Failure, Success, Redirect>,
-  ): LoaderFunction =>
+  ): BrandedDataFunction<Failure, Success, Redirect> =>
   (args: DataFunctionArgs) =>
-    loaderFn(args);
+    loaderFn(args, {
+      fail: Effect.fail,
+      succeed: Effect.succeed,
+      redirect: Effect.succeed,
+    });

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,21 @@ import {
   RedirectStatus,
 } from "./HttpStatusCode";
 
+export type BrandedDataFunction<
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  Failure extends StrongResponse<unknown, NonRedirectStatus>,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  Success extends StrongResponse<unknown, NonRedirectStatus>,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  Redirect extends StrongRedirect<string, RedirectStatus>,
+> = LoaderFunction & {
+  __brand?: {
+    Failure: Failure;
+    Success: Success;
+    Redirect: Redirect;
+  };
+};
+
 export interface _StrongResponse<T, S extends HttpStatusCode>
   extends ResponseInit {
   data: T;
@@ -37,12 +52,27 @@ export type PickDataAndStatus<T> = T extends StrongResponse<
   ? { data: T["data"]; status: T["status"] }
   : NonNullable<unknown>;
 
+export type StrongCallbacks<
+  Failure extends StrongResponse<unknown, NonRedirectStatus> = never,
+  Success extends StrongResponse<unknown, NonRedirectStatus> = never,
+  Redirect extends StrongRedirect<string, RedirectStatus> = never,
+> = {
+  fail: (failure: Failure) => Effect.Effect<never, Failure, Success | Redirect>;
+  succeed: (
+    success: Success,
+  ) => Effect.Effect<never, Failure, Success | Redirect>;
+  redirect: (
+    redirect: Redirect,
+  ) => Effect.Effect<never, Failure, Success | Redirect>;
+};
+
 export type StrongLoader<
   Failure extends StrongResponse<unknown, NonRedirectStatus> = never,
   Success extends StrongResponse<unknown, NonRedirectStatus> = never,
   Redirect extends StrongRedirect<string, RedirectStatus> = never,
 > = (
   args: LoaderArgs,
+  callbacks: StrongCallbacks<Failure, Success, Redirect>,
 ) => Promise<Effect.Effect<never, Failure, Success | Redirect>>;
 
 export type StrongAction<
@@ -51,6 +81,7 @@ export type StrongAction<
   Redirect extends StrongRedirect<string, RedirectStatus> = never,
 > = (
   args: ActionArgs,
+  callbacks: StrongCallbacks<Failure, Success, Redirect>,
 ) => Promise<Effect.Effect<never, Failure, Success | Redirect>>;
 
 export type StrongComponent<
@@ -70,8 +101,8 @@ export type BuildStrongRemixRouteExportsOpts<
   ActionRedirect extends StrongRedirect<string, RedirectStatus> = never,
 > = {
   routeId: string;
-  loader?: StrongLoader<LoaderFailure, LoaderSuccess, LoaderRedirect>;
-  action?: StrongAction<ActionFailure, ActionSuccess, ActionRedirect>;
+  loader?: BrandedDataFunction<LoaderFailure, LoaderSuccess, LoaderRedirect>;
+  action?: BrandedDataFunction<ActionFailure, ActionSuccess, ActionRedirect>;
   Component?: StrongComponent<LoaderSuccess>;
   ErrorBoundary?: StrongErrorBoundary<LoaderFailure | ActionFailure>;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,11 +18,8 @@ import {
 } from "./HttpStatusCode";
 
 export type BrandedDataFunction<
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   Failure extends StrongResponse<unknown, NonRedirectStatus>,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   Success extends StrongResponse<unknown, NonRedirectStatus>,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   Redirect extends StrongRedirect<string, RedirectStatus>,
 > = LoaderFunction & {
   __brand?: {


### PR DESCRIPTION
Ironic that I found an irl use case for the silliest TS quirk in a dusty corner of the Zod docs.