### PR TITLE
Add support for meta in `buildStrongRoute`

### DIFF
--- a/src/buildStrongRoute.tsx
+++ b/src/buildStrongRoute.tsx
@@ -96,7 +96,7 @@ export const buildStrongRoute = <
     RouteId
   >,
 ): StrongRemixRouteExports<typeof opts, Exclude<LoaderSuccess, never>> => {
-  const { loader, action, Component, ErrorBoundary } = opts;
+  const { loader, action, Component, ErrorBoundary, meta } = opts;
   const output = {} as StrongRemixRouteExports<typeof opts, LoaderSuccess>;
 
   if (loader) {
@@ -105,6 +105,10 @@ export const buildStrongRoute = <
 
   if (action) {
     output["action"] = async (args) => handleDataFunctionForRemix(action, args);
+  }
+
+  if (meta) {
+    output["meta"] = (args) => meta(args);
   }
 
   if (Component) {

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -21,6 +21,7 @@ import {
   strongLoader,
 } from "./";
 import { strongResponse } from "./strongResponse";
+import { StrongMeta } from "./types";
 
 describe("strongResponse", () => {
   it("should create and format a response with a data object and status code", async () => {
@@ -116,6 +117,14 @@ describe("buildStrongRoute", () => {
     return redirect(redirectResponse);
   });
 
+  const meta: StrongMeta<FooResponse | BazResponse> = ({ data }) => {
+    if (data) {
+      console.log(data.data);
+    }
+
+    return [];
+  };
+
   const Component: StrongComponent<FooResponse | BazResponse> = (props) => {
     if (props.status === HttpStatusCode.ACCEPTED) return null;
 
@@ -142,6 +151,7 @@ describe("buildStrongRoute", () => {
     ErrorBoundary,
     loader,
     action,
+    meta,
   });
 
   // TODO - add test cases for routeWithoutAction
@@ -451,6 +461,13 @@ describe("buildStrongRoute", () => {
           </pre>
         </div>
       `);
+    });
+  });
+
+  describe("meta", () => {
+    it("should return a empty aray", async () => {
+      const res = (route1 as any).meta({ data: {} } as any);
+      expect(res).toStrictEqual([]);
     });
   });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,10 +2,13 @@ import { V2_MetaFunction } from "@remix-run/react";
 import {
   RouteComponent,
   V2_ErrorBoundaryComponent,
+  V2_MetaArgs,
+  V2_MetaDescriptor,
 } from "@remix-run/react/dist/routeModules";
 import {
   ActionArgs,
   ActionFunction,
+  DataFunctionArgs,
   LoaderArgs,
   LoaderFunction,
 } from "@remix-run/server-runtime";
@@ -53,6 +56,12 @@ export type StrongLoader<
   Redirect extends StrongRedirect<string, RedirectStatus> = never,
 > = (args: LoaderArgs) => Promise<Either.Either<Failure, Success | Redirect>>;
 
+export type StrongMeta<
+  Success extends StrongResponse<unknown, NonRedirectStatus> = never,
+> = (
+  args: V2_MetaArgs<(args: DataFunctionArgs) => Promise<Success>>,
+) => V2_MetaDescriptor[];
+
 export type StrongAction<
   Failure extends StrongResponse<unknown, NonRedirectStatus> = never,
   Success extends StrongResponse<unknown, NonRedirectStatus> = never,
@@ -99,6 +108,7 @@ export type BuildStrongRemixRouteExportsOpts<
   action?: StrongAction<ActionFailure, ActionSuccess, ActionRedirect>;
   Component?: StrongComponent<LoaderSuccess>;
   ErrorBoundary?: StrongErrorBoundary<LoaderFailure | ActionFailure>;
+  meta?: StrongMeta<LoaderSuccess>;
 };
 
 export type StrongRemixRouteExports<


### PR DESCRIPTION
Extends `buildStrongRoute` to accept meta with `StrongMeta` type.